### PR TITLE
Add Slalom Build capability

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,15 @@ capabilities = {
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    },
+    "Slalom Build": {
+        "description": "Product strategy, design thinking, and full-stack digital product development for end-to-end innovation",
+        "practice_area": "Build",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Certified Product Manager", "SAFe Product Owner/Product Manager", "Agile Certified Practitioner", "Google UX Design Certificate"],
+        "industry_verticals": ["Consumer Products", "Fintech", "Healthtech"],
+        "capacity": 30,
+        "consultants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing **Slalom Build** capability to the capabilities management platform, as reported in issue #6.

## Changes

- Added `Slalom Build` entry to the in-memory capabilities database in `src/app.py`

## Capability Details

| Field | Value |
|---|---|
| Practice Area | Build |
| Skill Levels | Emerging, Proficient, Advanced, Expert |
| Certifications | Certified Product Manager, SAFe Product Owner/Product Manager, Agile Certified Practitioner, Google UX Design Certificate |
| Industry Verticals | Consumer Products, Fintech, Healthtech |
| Capacity | 30 hrs/week |

Closes #6